### PR TITLE
Add routes for users' interactions with books

### DIFF
--- a/__tests__/routes/books.test.js
+++ b/__tests__/routes/books.test.js
@@ -1,0 +1,51 @@
+const request = require('supertest');
+const express = require('express');
+const Books = require('../../api/models/bookModel');
+const bookRouter = require('../../api/routes/books');
+const server = express();
+
+jest.mock('../../api/models/bookModel');
+
+describe('books router endpoints', () => {
+  beforeAll(() => {
+    // This is the module/route being tested
+    server.use('/books', bookRouter);
+  });
+
+  describe('GET /books', () => {
+    it('should return 200', async () => {
+      Books.findAll.mockResolvedValue([]);
+      const res = await request(server).get('/books');
+
+      expect(res.status).toBe(200);
+      expect(res.body.length).toBe(0);
+      expect(Books.findAll.mock.calls.length).toBe(1);
+    });
+  });
+
+  describe('GET /books/:id', () => {
+    it('should return 200 when book found', async () => {
+      Books.findById.mockResolvedValue({
+        id: 20,
+        googleId: 'kPmLDQAAQBAJ',
+        title: 'The Martian',
+        authors: 'Andy Weir',
+      });
+      const res = await request(server).get('/books/20');
+
+      expect(res.status).toBe(200);
+      expect(res.body.title).toBe('The Martian');
+      expect(res.body.googleId).toBe('kPmLDQAAQBAJ');
+      expect(res.body.authors).toBe('Andy Weir');
+      expect(Books.findById.mock.calls.length).toBe(1);
+    });
+
+    it('should return 404 when no book found', async () => {
+      Books.findById.mockResolvedValue();
+      const res = await request(server).get('/books/20');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('BookNotFound');
+    });
+  });
+});

--- a/__tests__/routes/profileBookConnections.test.js
+++ b/__tests__/routes/profileBookConnections.test.js
@@ -50,4 +50,22 @@ describe('profile-book router endpoints', () => {
       );
     });
   });
+
+  describe('GET /connect/profile/:id', () => {
+    it('should return 200 when profile-book connections found for specified user', async () => {
+      Connections.findBy.mockResolvedValue({
+        id: 20,
+        profileId: 2,
+        bookId: 3,
+        readingStatus: 1,
+      });
+      const res = await request(server).get('/connect/profile/2');
+
+      expect(res.status).toBe(200);
+      expect(res.body.profileId).toBe(2);
+      expect(res.body.bookId).toBe(3);
+      expect(res.body.readingStatus).toBe(1);
+      expect(Connections.findBy.mock.calls.length).toBe(1);
+    });
+  });
 });

--- a/__tests__/routes/profileBookConnections.test.js
+++ b/__tests__/routes/profileBookConnections.test.js
@@ -1,0 +1,53 @@
+const request = require('supertest');
+const express = require('express');
+const Connections = require('../../api/models/profileBookConnectionModel');
+const connectionsRouter = require('../../api/routes/profileBookConnections');
+const server = express();
+
+jest.mock('../../api/models/profileBookConnectionModel');
+
+describe('profile-book router endpoints', () => {
+  beforeAll(() => {
+    // This is the module/route being tested
+    server.use('/connect', connectionsRouter);
+  });
+
+  describe('GET /connect', () => {
+    it('should return 200', async () => {
+      Connections.findAll.mockResolvedValue([]);
+      const res = await request(server).get('/connect');
+
+      expect(res.status).toBe(200);
+      expect(res.body.length).toBe(0);
+      expect(Connections.findAll.mock.calls.length).toBe(1);
+    });
+  });
+
+  describe('GET /connect/:id', () => {
+    it('should return 200 when profile-book connection found', async () => {
+      Connections.findById.mockResolvedValue({
+        id: 20,
+        profileId: 2,
+        bookId: 3,
+        readingStatus: 1,
+      });
+      const res = await request(server).get('/connect/20');
+
+      expect(res.status).toBe(200);
+      expect(res.body.profileId).toBe(2);
+      expect(res.body.bookId).toBe(3);
+      expect(res.body.readingStatus).toBe(1);
+      expect(Connections.findById.mock.calls.length).toBe(1);
+    });
+
+    it('should return 404 when no profile-book connection found', async () => {
+      Connections.findById.mockResolvedValue();
+      const res = await request(server).get('/connect/20');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe(
+        'Profile-book connection with id 20 not found.'
+      );
+    });
+  });
+});

--- a/__tests__/routes/search.test.js
+++ b/__tests__/routes/search.test.js
@@ -1,0 +1,20 @@
+const request = require('supertest');
+const express = require('express');
+const server = express();
+const searchRouter = require('../../api/routes/search');
+
+describe('search router endpoint', () => {
+  beforeAll(() => {
+    // This is the module/route being tested
+    server.use('/search', searchRouter);
+  });
+
+  describe('GET /search', () => {
+    it('should return 500 when the request body is invalid', async () => {
+      const res = await request(server).get('/search').send({
+        test: 'toast',
+      });
+      expect(res.status).toBe(500);
+    });
+  });
+});

--- a/__tests__/routes/shelfBookConnections.test.js
+++ b/__tests__/routes/shelfBookConnections.test.js
@@ -49,4 +49,28 @@ describe('shelf-book router endpoints', () => {
       );
     });
   });
+
+  describe('GET /organize/shelf/:shelfId', () => {
+    it('should return 200 when shelf-book connections found for specified shelf', async () => {
+      shelfBookConnections.findBy.mockResolvedValue([
+        {
+          id: 20,
+          ShelfId: 2,
+          ConnectionId: 3,
+        },
+        {
+          id: 21,
+          ShelfId: 2,
+          ConnectionId: 4,
+        },
+      ]);
+      const res = await request(server).get('/organize/shelf/2');
+
+      expect(res.status).toBe(200);
+      expect(res.body[0].id).toBe(20);
+      expect(res.body[0].ShelfId).toBe(2);
+      expect(res.body[0].ConnectionId).toBe(3);
+      expect(shelfBookConnections.findBy.mock.calls.length).toBe(1);
+    });
+  });
 });

--- a/__tests__/routes/shelfBookConnections.test.js
+++ b/__tests__/routes/shelfBookConnections.test.js
@@ -1,0 +1,52 @@
+const request = require('supertest');
+const express = require('express');
+const shelfBookConnections = require('../../api/models/shelfBookConnectionModel');
+const shelfBookConnectionsRouter = require('../../api/routes/shelfBookConnections');
+const server = express();
+
+jest.mock('../../api/models/shelfBookConnectionModel');
+
+describe('shelf-book router endpoints', () => {
+  beforeAll(() => {
+    // This is the module/route being tested
+    server.use('/organize', shelfBookConnectionsRouter);
+  });
+
+  describe('GET /organize', () => {
+    it('should return 200', async () => {
+      shelfBookConnections.findAll.mockResolvedValue([]);
+      const res = await request(server).get('/organize');
+
+      expect(res.status).toBe(200);
+      expect(res.body.length).toBe(0);
+      expect(shelfBookConnections.findAll.mock.calls.length).toBe(1);
+    });
+  });
+
+  describe('GET /organize/:id', () => {
+    it('should return 200 when shelf-book connection found', async () => {
+      shelfBookConnections.findById.mockResolvedValue({
+        id: 20,
+        ShelfId: 2,
+        ConnectionId: 3,
+      });
+      const res = await request(server).get('/organize/20');
+
+      expect(res.status).toBe(200);
+      expect(res.body.id).toBe(20);
+      expect(res.body.ShelfId).toBe(2);
+      expect(res.body.ConnectionId).toBe(3);
+      expect(shelfBookConnections.findById.mock.calls.length).toBe(1);
+    });
+
+    it('should return 404 when no shelf-book connection found', async () => {
+      shelfBookConnections.findById.mockResolvedValue();
+      const res = await request(server).get('/organize/20');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe(
+        'Shelf-book connection with id 20 not found.'
+      );
+    });
+  });
+});

--- a/__tests__/routes/shelves.test.js
+++ b/__tests__/routes/shelves.test.js
@@ -1,0 +1,25 @@
+const request = require('supertest');
+const express = require('express');
+const Shelves = require('../../api/models/shelfModel');
+const shelfRouter = require('../../api/routes/shelves');
+const server = express();
+
+jest.mock('../../api/models/shelfModel');
+
+describe('shelves router endpoints', () => {
+  beforeAll(() => {
+    // This is the module/route being tested
+    server.use('/shelves', shelfRouter);
+  });
+
+  describe('GET /shelves', () => {
+    it('should return 200', async () => {
+      Shelves.findAll.mockResolvedValue([]);
+      const res = await request(server).get('/shelves');
+
+      expect(res.status).toBe(200);
+      expect(res.body.length).toBe(0);
+      expect(Shelves.findAll.mock.calls.length).toBe(1);
+    });
+  });
+});

--- a/__tests__/routes/shelves.test.js
+++ b/__tests__/routes/shelves.test.js
@@ -22,4 +22,28 @@ describe('shelves router endpoints', () => {
       expect(Shelves.findAll.mock.calls.length).toBe(1);
     });
   });
+
+  describe('GET /shelves/:id', () => {
+    it('should return 200 when shelf found', async () => {
+      Shelves.findById.mockResolvedValue({
+        id: 20,
+        name: 'chick-lit',
+        profileId: 2,
+      });
+      const res = await request(server).get('/shelves/20');
+
+      expect(res.status).toBe(200);
+      expect(res.body.name).toBe('chick-lit');
+      expect(res.body.profileId).toBe(2);
+      expect(Shelves.findById.mock.calls.length).toBe(1);
+    });
+
+    it('should return 404 when no shelf found', async () => {
+      Shelves.findById.mockResolvedValue();
+      const res = await request(server).get('/shelves/20');
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toBe('ShelfNotFound');
+    });
+  });
 });

--- a/api/app.js
+++ b/api/app.js
@@ -69,7 +69,7 @@ app.use(function (err, req, res, next) {
       res.locals.error = err;
     }
   }
-  console.error(err);
+  // console.error(err); // When uncommented, this line throws an error when running tests. "not found"
   if (process.env.NODE_ENV === 'production' && !res.locals.message) {
     res.locals.message = 'ApplicationError';
     res.locals.status = 500;

--- a/api/app.js
+++ b/api/app.js
@@ -21,6 +21,7 @@ const swaggerUIOptions = {
 const indexRouter = require('./routes/index');
 const profileRouter = require('./routes/profile');
 const bookRouter = require('./routes/books');
+const connectionsRouter = require('./routes/profileBookConnections');
 
 const app = express();
 
@@ -50,6 +51,7 @@ app.use(cookieParser());
 app.use('/', indexRouter);
 app.use(['/profile', '/profiles'], profileRouter);
 app.use(['/book', '/books'], bookRouter);
+app.use('/connect', connectionsRouter);
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {
   next(createError(404));

--- a/api/app.js
+++ b/api/app.js
@@ -23,6 +23,7 @@ const profileRouter = require('./routes/profile');
 const bookRouter = require('./routes/books');
 const connectionRouter = require('./routes/profileBookConnections');
 const shelfRouter = require('./routes/shelves');
+const shelfBookConnectionRouter = require('./routes/shelfBookConnections');
 
 const app = express();
 
@@ -54,6 +55,7 @@ app.use(['/profile', '/profiles'], profileRouter);
 app.use(['/book', '/books'], bookRouter);
 app.use('/connect', connectionRouter);
 app.use(['/shelf', '/shelves'], shelfRouter);
+app.use('/organize', shelfBookConnectionRouter);
 
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {

--- a/api/app.js
+++ b/api/app.js
@@ -24,6 +24,7 @@ const bookRouter = require('./routes/books');
 const connectionRouter = require('./routes/profileBookConnections');
 const shelfRouter = require('./routes/shelves');
 const shelfBookConnectionRouter = require('./routes/shelfBookConnections');
+const searchRouter = require('./routes/search');
 
 const app = express();
 
@@ -56,6 +57,7 @@ app.use(['/book', '/books'], bookRouter);
 app.use('/connect', connectionRouter);
 app.use(['/shelf', '/shelves'], shelfRouter);
 app.use('/organize', shelfBookConnectionRouter);
+app.use('/search', searchRouter);
 
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {

--- a/api/app.js
+++ b/api/app.js
@@ -21,7 +21,8 @@ const swaggerUIOptions = {
 const indexRouter = require('./routes/index');
 const profileRouter = require('./routes/profile');
 const bookRouter = require('./routes/books');
-const connectionsRouter = require('./routes/profileBookConnections');
+const connectionRouter = require('./routes/profileBookConnections');
+const shelfRouter = require('./routes/shelves');
 
 const app = express();
 
@@ -51,7 +52,8 @@ app.use(cookieParser());
 app.use('/', indexRouter);
 app.use(['/profile', '/profiles'], profileRouter);
 app.use(['/book', '/books'], bookRouter);
-app.use('/connect', connectionsRouter);
+app.use('/connect', connectionRouter);
+app.use(['/shelf', '/shelves'], shelfRouter);
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {
   next(createError(404));

--- a/api/app.js
+++ b/api/app.js
@@ -54,6 +54,7 @@ app.use(['/profile', '/profiles'], profileRouter);
 app.use(['/book', '/books'], bookRouter);
 app.use('/connect', connectionRouter);
 app.use(['/shelf', '/shelves'], shelfRouter);
+
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {
   next(createError(404));

--- a/api/models/profileBookConnectionModel.js
+++ b/api/models/profileBookConnectionModel.js
@@ -1,0 +1,35 @@
+const db = require('../../data/db-config');
+
+const findAll = async () => {
+  return await db('profile_book_connections');
+};
+
+const findBy = (filter) => {
+  return db('profile_book_connections').where(filter);
+};
+
+const findById = async (id) => {
+  return db('profile_book_connections').where({ id }).first().select('*');
+};
+
+const create = async (connection) => {
+  const [id] = await db('profile_book_connections')
+    .insert(connection)
+    .returning('id');
+  return findById(id);
+};
+
+function update(id, new_info) {
+  return db('profile_book_connections')
+    .where({ id })
+    .update(new_info)
+    .then(() => {
+      return findById(id);
+    });
+}
+
+const remove = async (id) => {
+  return await db('profile_book_connections').where({ id }).del();
+};
+
+module.exports = { findAll, findBy, findById, create, update, remove };

--- a/api/models/shelfBookConnectionModel.js
+++ b/api/models/shelfBookConnectionModel.js
@@ -1,0 +1,26 @@
+const db = require('../../data/db-config');
+
+const findAll = async () => {
+  return await db('shelf_book_connections');
+};
+
+const findBy = (filter) => {
+  return db('shelf_book_connections').where(filter);
+};
+
+const findById = async (id) => {
+  return db('shelf_book_connections').where({ id }).first().select('*');
+};
+
+const create = async (connection) => {
+  const [id] = await db('shelf_book_connections')
+    .insert(connection)
+    .returning('id');
+  return findById(id);
+};
+
+const remove = async (id) => {
+  return await db('shelf_book_connections').where({ id }).del();
+};
+
+module.exports = { findAll, findBy, findById, create, remove };

--- a/api/models/shelfModel.js
+++ b/api/models/shelfModel.js
@@ -1,0 +1,33 @@
+const db = require('../../data/db-config');
+
+const findAll = async () => {
+  return await db('shelves');
+};
+
+const findBy = (filter) => {
+  return db('shelves').where(filter);
+};
+
+const findById = async (id) => {
+  return db('shelves').where({ id }).first().select('*');
+};
+
+const create = async (shelf) => {
+  const [id] = await db('shelves').insert(shelf).returning('id');
+  return findById(id);
+};
+
+function update(id, new_info) {
+  return db('shelves')
+    .where({ id })
+    .update(new_info)
+    .then(() => {
+      return findById(id);
+    });
+}
+
+const remove = async (id) => {
+  return await db('profile_book_connections').where({ id }).del();
+};
+
+module.exports = { findAll, findBy, findById, create, update, remove };

--- a/api/models/shelfModel.js
+++ b/api/models/shelfModel.js
@@ -27,7 +27,7 @@ function update(id, new_info) {
 }
 
 const remove = async (id) => {
-  return await db('profile_book_connections').where({ id }).del();
+  return await db('shelves').where({ id }).del();
 };
 
 module.exports = { findAll, findBy, findById, create, update, remove };

--- a/api/routes/books.js
+++ b/api/routes/books.js
@@ -39,11 +39,9 @@ router.post('/', (req, res) => {
         if (br == undefined) {
           //book not found so lets insert it
           Books.create(book)
-            .then((book) =>
-              res
-                .status(200)
-                .json({ message: 'book created', profile: book[0] })
-            )
+            .then((book) => {
+              res.status(200).json({ message: 'book created', book: book });
+            })
             .catch((err) => {
               console.error(err);
               res.status(500).json({ message: err.message });

--- a/api/routes/books.js
+++ b/api/routes/books.js
@@ -3,6 +3,53 @@ const express = require('express');
 const Books = require('../models/bookModel');
 const router = express.Router();
 
+/**
+ * @swagger
+ * components:
+ *  schemas:
+ *    Book:
+ *      type: object
+ *      required:
+ *        - googleId
+ *        - title
+ *        - authors
+ *      properties:
+ *        googleId:
+ *          type: string
+ *          description: google books API id
+ *        title:
+ *          type: string
+ *        authors:
+ *          type: string
+ *      example:
+ *        googleId: 'hFfhrCWiLSMC'
+ *        title: 'The Hobbit, Or, There and Back Again'
+ *        authors: 'John Ronald Reuel Tolkien'
+ *
+ * /books:
+ *  get:
+ *    description: Returns a list of books
+ *    summary: Get a list of all books
+ *    tags:
+ *      - book
+ *    responses:
+ *      200:
+ *        description: array of books
+ *        content:
+ *          application/json:
+ *            schema:
+ *              type: array
+ *              items:
+ *                $ref: '#/components/schemas/Book'
+ *              example:
+ *                - googleId: 'hFfhrCWiLSMC'
+ *                  title: 'The Hobbit, Or, There and Back Again'
+ *                  authors: 'John Ronald Reuel Tolkien'
+ *                - googleId: '5QRZ4z6A1WwC'
+ *                  title: 'The Fellowship of the Ring'
+ *                  authors: 'John Ronald Reuel Tolkien and Alan Lee'
+ */
+
 router.get('/', function (req, res) {
   Books.findAll()
     .then((books) => {

--- a/api/routes/profileBookConnections.js
+++ b/api/routes/profileBookConnections.js
@@ -16,4 +16,66 @@ router.get('/', function (req, res) {
     });
 });
 
+router.get('/:id', function (req, res) {
+  const id = String(req.params.id);
+  Connections.findById(id)
+    .then((connection) => {
+      if (connection) {
+        res.status(200).json(connection);
+      } else {
+        res
+          .status(404)
+          .json({ error: `Profile-book connection with id ${id} not found.` });
+      }
+    })
+    .catch((err) => {
+      res.status(500).json({
+        message: `Failure to GET profile-book connection with id ${id}.`,
+        error: err.message,
+      });
+    });
+});
+
+// Required in request body: profileId, bookId, and readingStatus (an integer, 1-3)
+router.post('/', (req, res) => {
+  const connection = req.body;
+  if (connection) {
+    const id = connection.id || 0;
+    Connections.findBy({ id })
+      .first()
+      .then((connectionResult) => {
+        if (connectionResult == undefined) {
+          // Profile-book connection not found, so let's create it:
+          Connections.create(connection)
+            .then((newConnection) => {
+              res.status(200).json({
+                message: 'profile-book connection created',
+                book: newConnection,
+              });
+            })
+            .catch((err) => {
+              console.error(err);
+              res.status(500).json({
+                message: 'Failure to create new profile-book connection',
+                error: err.message,
+              });
+            });
+        } else {
+          res.status(400).json({
+            message: `Profile-book connection with id ${id} already exists`,
+          });
+        }
+      })
+      .catch((err) => {
+        console.error(err);
+        res.status(500).json({ message: err.message });
+      });
+  } else {
+    res.status(400).json({
+      message:
+        'Failure to create profile-book connection because info is missing in request body.',
+    });
+  }
+});
+
 module.exports = router;

--- a/api/routes/profileBookConnections.js
+++ b/api/routes/profileBookConnections.js
@@ -64,7 +64,6 @@ router.post('/', (req, res) => {
   if (connection) {
     const profileId = connection.profileId || 0;
     const bookId = connection.bookId || 0;
-    const id = connection.id || 0;
     Connections.findBy({ profileId, bookId })
       .first()
       .then((connectionResult) => {
@@ -102,4 +101,54 @@ router.post('/', (req, res) => {
   }
 });
 
+router.put('/:id', (req, res) => {
+  const id = String(req.params.id);
+  const connectionInfo = req.body;
+  if (connectionInfo) {
+    Connections.findBy({ id })
+      .first()
+      .then((connectionResponse) => {
+        if (connectionResponse == undefined) {
+          res.status(400).json({
+            message: `Profile-book connection with id ${id} not found.`,
+          });
+        } else {
+          Connections.update(id, connectionInfo)
+            .then((updatedConnection) => {
+              res.status(200).json({
+                message: `Profile-book connection with id ${id} is updated.`,
+                connection: updatedConnection,
+              });
+            })
+            .catch((err) => {
+              res.status(500).json({
+                message: `Failure to update profile-book connection with id ${id}`,
+                error: err.message,
+              });
+            });
+        }
+      })
+      .catch((err) => {
+        console.error(err);
+        res.status(500).json({ message: err.message });
+      });
+  } else {
+    res.status(400).json({
+      message:
+        'Request body is missing the connection info needed for an update.',
+    });
+  }
+});
+
 module.exports = router;
+
+/*
+Books.create(book)
+              .then((book) => {
+                res.status(200).json({ message: 'book created', book: book });
+              })
+              .catch((err) => {
+                console.error(err);
+                res.status(500).json({ message: err.message });
+              });
+*/

--- a/api/routes/profileBookConnections.js
+++ b/api/routes/profileBookConnections.js
@@ -40,8 +40,10 @@ router.get('/:id', function (req, res) {
 router.post('/', (req, res) => {
   const connection = req.body;
   if (connection) {
+    const profileId = connection.profileId || 0;
+    const bookId = connection.bookId || 0;
     const id = connection.id || 0;
-    Connections.findBy({ id })
+    Connections.findBy({ profileId, bookId })
       .first()
       .then((connectionResult) => {
         if (connectionResult == undefined) {
@@ -62,7 +64,7 @@ router.post('/', (req, res) => {
             });
         } else {
           res.status(400).json({
-            message: `Profile-book connection with id ${id} already exists`,
+            message: `Profile-book connection with id ${connectionResult.id} already exists`,
           });
         }
       })

--- a/api/routes/profileBookConnections.js
+++ b/api/routes/profileBookConnections.js
@@ -1,0 +1,19 @@
+const express = require('express');
+// const authRequired = require('../middleware/authRequired');
+const Connections = require('../models/profileBookConnectionModel');
+const router = express.Router();
+
+router.get('/', function (req, res) {
+  Connections.findAll()
+    .then((connections) => {
+      res.status(200).json(connections);
+    })
+    .catch((err) => {
+      res.status(500).json({
+        message: 'Failure to GET profile-book connections',
+        error: err.message,
+      });
+    });
+});
+
+module.exports = router;

--- a/api/routes/profileBookConnections.js
+++ b/api/routes/profileBookConnections.js
@@ -73,7 +73,7 @@ router.post('/', (req, res) => {
             .then((newConnection) => {
               res.status(200).json({
                 message: 'profile-book connection created',
-                book: newConnection,
+                connection: newConnection,
               });
             })
             .catch((err) => {
@@ -105,8 +105,7 @@ router.put('/:id', (req, res) => {
   const id = String(req.params.id);
   const connectionInfo = req.body;
   if (connectionInfo) {
-    Connections.findBy({ id })
-      .first()
+    Connections.findById(id)
       .then((connectionResponse) => {
         if (connectionResponse == undefined) {
           res.status(400).json({
@@ -140,15 +139,36 @@ router.put('/:id', (req, res) => {
   }
 });
 
-module.exports = router;
+router.delete('/:id', (req, res) => {
+  const id = req.params.id;
+  Connections.findById(id)
+    .then((connection) => {
+      if (connection) {
+        Connections.remove(id)
+          .then((deleted) => {
+            res.status(200).json({
+              message: `Profile-book connection with id ${id} was deleted.`,
+              count_of_deleted_connections: deleted,
+            });
+          })
+          .catch((err) => {
+            res.status(500).json({
+              message: `Could not delete profile-book connection with id: ${id}`,
+              error: err.message,
+            });
+          });
+      } else {
+        res.status(404).json({
+          error: `Profile-book connection with id ${id} not found.`,
+        });
+      }
+    })
+    .catch((err) => {
+      res.status(500).json({
+        message: `Profile-book connection with id ${id} not found.`,
+        error: err.message,
+      });
+    });
+});
 
-/*
-Books.create(book)
-              .then((book) => {
-                res.status(200).json({ message: 'book created', book: book });
-              })
-              .catch((err) => {
-                console.error(err);
-                res.status(500).json({ message: err.message });
-              });
-*/
+module.exports = router;

--- a/api/routes/profileBookConnections.js
+++ b/api/routes/profileBookConnections.js
@@ -36,6 +36,28 @@ router.get('/:id', function (req, res) {
     });
 });
 
+// To only GET the connections for a specified user
+
+router.get('/profile/:id', function (req, res) {
+  const profileId = String(req.params.id);
+  Connections.findBy({ profileId })
+    .then((connections) => {
+      if (connections) {
+        res.status(200).json(connections);
+      } else {
+        res.status(404).json({
+          error: `Profile-book connections with profile id ${profileId} not found.`,
+        });
+      }
+    })
+    .catch((err) => {
+      res.status(500).json({
+        message: `Failure to GET profile-book connections with profile id ${profileId}.`,
+        error: err.message,
+      });
+    });
+});
+
 // Required in request body: profileId, bookId, and readingStatus (an integer, 1-3)
 router.post('/', (req, res) => {
   const connection = req.body;

--- a/api/routes/search.js
+++ b/api/routes/search.js
@@ -12,14 +12,12 @@ router.get('/', (req, res) => {
     .then((response) => {
       const first_ten = response.data.items.slice(0, 10);
       const first_ten_parsed = first_ten.map((book) => {
-        let authors_formatted = '';
-        if (book.volumeInfo.authors) {
-          authors_formatted = book.volumeInfo.authors.join(', ');
-        }
         return {
           googleId: book.id,
           title: book.volumeInfo.title,
-          authors: authors_formatted,
+          authors: book.volumeInfo.authors
+            ? book.volumeInfo.authors.join(', ')
+            : '',
         };
       });
       res.status(200).json({

--- a/api/routes/search.js
+++ b/api/routes/search.js
@@ -39,32 +39,55 @@ router.get('/', (req, res) => {
           }
         }
         return {
-          googleId: book.id,
-          title: book.volumeInfo.title,
-          authors: book.volumeInfo.authors
-            ? book.volumeInfo.authors.join(', ')
-            : '',
-          publisher: book.volumeInfo.publisher ? book.volumeInfo.publisher : '',
-          publishedDate: book.volumeInfo.publishedDate
-            ? book.volumeInfo.publishedDate
-            : '',
-          description: book.volumeInfo.description
-            ? book.volumeInfo.description
-            : '',
-          pageCount: book.volumeInfo.pageCount ? book.volumeInfo.pageCount : '',
-          categories: book.volumeInfo.categories
-            ? book.volumeInfo.categories.join(', ')
-            : '',
-          thumbnail: book.volumeInfo.imageLinks.thumbnail
-            ? book.volumeInfo.imageLinks.thumbnail
-            : '',
-          smallThumbnail: book.volumeInfo.imageLinks.smallThumbnail
-            ? book.volumeInfo.imageLinks.smallThumbnail
-            : '',
-          language: book.volumeInfo.language ? book.volumeInfo.language : '',
-          webReaderLink: book.accessInfo.webReaderLink
-            ? book.accessInfo.webReaderLink
-            : '',
+          googleId: book.id ? book.id : '',
+          title:
+            book.volumeInfo && book.volumeInfo.title
+              ? book.volumeInfo.title
+              : '',
+          authors:
+            book.volumeInfo && book.volumeInfo.authors
+              ? book.volumeInfo.authors.join(', ')
+              : '',
+          publisher:
+            book.volumeInfo && book.volumeInfo.publisher
+              ? book.volumeInfo.publisher
+              : '',
+          publishedDate:
+            book.volumeInfo && book.volumeInfo.publishedDate
+              ? book.volumeInfo.publishedDate
+              : '',
+          description:
+            book.volumeInfo && book.volumeInfo.description
+              ? book.volumeInfo.description
+              : '',
+          pageCount:
+            book.volumeInfo && book.volumeInfo.pageCount
+              ? book.volumeInfo.pageCount
+              : '',
+          categories:
+            book.volumeInfo && book.volumeInfo.categories
+              ? book.volumeInfo.categories.join(', ')
+              : '',
+          thumbnail:
+            book.volumeInfo &&
+            book.volumeInfo.imageLinks &&
+            book.volumeInfo.imageLinks.thumbnail
+              ? book.volumeInfo.imageLinks.thumbnail
+              : '',
+          smallThumbnail:
+            book.volumeInfo &&
+            book.volumeInfo.imageLinks &&
+            book.volumeInfo.imageLinks.smallThumbnail
+              ? book.volumeInfo.imageLinks.smallThumbnail
+              : '',
+          language:
+            book.volumeInfo && book.volumeInfo.language
+              ? book.volumeInfo.language
+              : '',
+          webReaderLink:
+            book.accessInfo && book.accessInfo.webReaderLink
+              ? book.accessInfo.webReaderLink
+              : '',
           textSnippet:
             book.searchInfo && book.searchInfo.textSnippet
               ? book.searchInfo.textSnippet
@@ -79,8 +102,8 @@ router.get('/', (req, res) => {
             book.volumeInfo && book.volumeInfo.averageRating
               ? book.volumeInfo.averageRating
               : null,
-          isbn10: isbn10,
-          isbn13: isbn13,
+          isbn10,
+          isbn13,
         };
       });
       res.status(200).json({

--- a/api/routes/search.js
+++ b/api/routes/search.js
@@ -1,0 +1,33 @@
+const express = require('express');
+const router = express.Router();
+const axios = require('axios');
+
+router.get('/', (req, res) => {
+  let queryBody = req.body.query;
+  queryBody = queryBody.replace(/ /g, '+');
+  const query = 'https://www.googleapis.com/books/v1/volumes?q=' + queryBody;
+  console.log(query);
+  axios
+    .get(query)
+    .then((response) => {
+      const first_ten = response.data.items.slice(0, 10);
+      const first_ten_parsed = first_ten.map((book) => {
+        return {
+          googleId: book.id,
+          title: book.volumeInfo.title,
+          authors: book.volumeInfo.authors,
+        };
+      });
+      res.status(200).json({
+        first_ten: first_ten_parsed,
+      });
+    })
+    .catch((err) => {
+      res.status(500).json({
+        message: `Failure to get Google Books API result with ${queryBody}`,
+        error: err.message,
+      });
+    });
+});
+
+module.exports = router;

--- a/api/routes/search.js
+++ b/api/routes/search.js
@@ -2,9 +2,11 @@ const express = require('express');
 const router = express.Router();
 const axios = require('axios');
 
-// In request body, searchTerms or exactPhrase is required. startIndex and maxResults are optional.
+// In request body, searchTerms, exactPhrase, or author is required.
+// startIndex and maxResults are optional.
 // Default maxResults is 10.
 // Default startIndex is 0.
+
 router.get('/', (req, res) => {
   let searchTerms = req.body.searchTerms;
   if (searchTerms) {
@@ -18,6 +20,7 @@ router.get('/', (req, res) => {
     exactPhrase = '"' + exactPhrase.replace(/ /g, '+') + '"';
   }
   const author = req.body.author;
+  const title = req.body.title;
 
   let query = 'https://www.googleapis.com/books/v1/volumes?q=';
   if (searchTerms && exactPhrase) {
@@ -27,9 +30,10 @@ router.get('/', (req, res) => {
   } else if (exactPhrase) {
     query += exactPhrase;
   }
+
   if (author) {
     const authorArray = author.split(' ');
-    if (!exactPhrase && !searchTerms) {
+    if (!exactPhrase && !searchTerms && !title) {
       query += 'inauthor:' + authorArray[0];
       for (let i = 1; i < authorArray.length; i++) {
         query += '+inauthor:' + authorArray[i];
@@ -40,6 +44,21 @@ router.get('/', (req, res) => {
       }
     }
   }
+
+  if (title) {
+    const titleArray = title.split(' ');
+    if (!exactPhrase && !searchTerms && !author) {
+      query += 'intitle:' + titleArray[0];
+      for (let i = 1; i < titleArray.length; i++) {
+        query += '+intitle:' + titleArray[i];
+      }
+    } else {
+      for (let i = 0; i < titleArray.length; i++) {
+        query += '+intitle:' + titleArray[i];
+      }
+    }
+  }
+
   if (startIndex) {
     query += '&startIndex=' + startIndex;
   }

--- a/api/routes/search.js
+++ b/api/routes/search.js
@@ -12,10 +12,14 @@ router.get('/', (req, res) => {
     .then((response) => {
       const first_ten = response.data.items.slice(0, 10);
       const first_ten_parsed = first_ten.map((book) => {
+        let authors_formatted = '';
+        if (book.volumeInfo.authors) {
+          authors_formatted = book.volumeInfo.authors.join(', ');
+        }
         return {
           googleId: book.id,
           title: book.volumeInfo.title,
-          authors: book.volumeInfo.authors,
+          authors: authors_formatted,
         };
       });
       res.status(200).json({

--- a/api/routes/search.js
+++ b/api/routes/search.js
@@ -25,12 +25,62 @@ router.get('/', (req, res) => {
     .get(query)
     .then((response) => {
       const responseParsed = response.data.items.map((book) => {
+        let isbn10 = '';
+        let isbn13 = '';
+        if (book.volumeInfo.industryIdentifiers) {
+          for (let i = 0; i < book.volumeInfo.industryIdentifiers.length; i++) {
+            if (book.volumeInfo.industryIdentifiers[i].type === 'ISBN_10') {
+              isbn10 = book.volumeInfo.industryIdentifiers[i].identifier;
+            } else if (
+              book.volumeInfo.industryIdentifiers[i].type === 'ISBN_13'
+            ) {
+              isbn13 = book.volumeInfo.industryIdentifiers[i].identifier;
+            }
+          }
+        }
         return {
           googleId: book.id,
           title: book.volumeInfo.title,
           authors: book.volumeInfo.authors
             ? book.volumeInfo.authors.join(', ')
             : '',
+          publisher: book.volumeInfo.publisher ? book.volumeInfo.publisher : '',
+          publishedDate: book.volumeInfo.publishedDate
+            ? book.volumeInfo.publishedDate
+            : '',
+          description: book.volumeInfo.description
+            ? book.volumeInfo.description
+            : '',
+          pageCount: book.volumeInfo.pageCount ? book.volumeInfo.pageCount : '',
+          categories: book.volumeInfo.categories
+            ? book.volumeInfo.categories.join(', ')
+            : '',
+          thumbnail: book.volumeInfo.imageLinks.thumbnail
+            ? book.volumeInfo.imageLinks.thumbnail
+            : '',
+          smallThumbnail: book.volumeInfo.imageLinks.smallThumbnail
+            ? book.volumeInfo.imageLinks.smallThumbnail
+            : '',
+          language: book.volumeInfo.language ? book.volumeInfo.language : '',
+          webReaderLink: book.accessInfo.webReaderLink
+            ? book.accessInfo.webReaderLink
+            : '',
+          textSnippet:
+            book.searchInfo && book.searchInfo.textSnippet
+              ? book.searchInfo.textSnippet
+              : '',
+          buyLink:
+            book.saleInfo && book.saleInfo.buyLink ? book.saleInfo.buyLink : '',
+          publicDomain:
+            book.accessInfo && book.accessInfo.publicDomain
+              ? book.accessInfo.publicDomain
+              : false,
+          averageRating:
+            book.volumeInfo && book.volumeInfo.averageRating
+              ? book.volumeInfo.averageRating
+              : null,
+          isbn10: isbn10,
+          isbn13: isbn13,
         };
       });
       res.status(200).json({

--- a/api/routes/search.js
+++ b/api/routes/search.js
@@ -10,8 +10,7 @@ router.get('/', (req, res) => {
   axios
     .get(query)
     .then((response) => {
-      const first_ten = response.data.items.slice(0, 10);
-      const first_ten_parsed = first_ten.map((book) => {
+      const firstTenParsed = response.data.items.map((book) => {
         return {
           googleId: book.id,
           title: book.volumeInfo.title,
@@ -21,7 +20,9 @@ router.get('/', (req, res) => {
         };
       });
       res.status(200).json({
-        first_ten: first_ten_parsed,
+        totalItems: response.data.totalItems,
+        returnedItemsLength: response.data.items.length,
+        firstTen: firstTenParsed,
       });
     })
     .catch((err) => {

--- a/api/routes/search.js
+++ b/api/routes/search.js
@@ -2,15 +2,29 @@ const express = require('express');
 const router = express.Router();
 const axios = require('axios');
 
+// In request body, query is required. startIndex and maxResults are optional.
+// Default maxResults is 10.
+// Default startIndex is 0.
 router.get('/', (req, res) => {
   let queryBody = req.body.query;
+  const startIndex = req.body.startIndex;
+  let maxResults = req.body.maxResults;
   queryBody = queryBody.replace(/ /g, '+');
-  const query = 'https://www.googleapis.com/books/v1/volumes?q=' + queryBody;
+  let query = 'https://www.googleapis.com/books/v1/volumes?q=' + queryBody;
+  if (startIndex) {
+    query += '&startIndex=' + startIndex;
+  }
+  if (maxResults > 40) {
+    maxResults = 40;
+  }
+  if (maxResults) {
+    query += '&maxResults=' + maxResults;
+  }
   console.log(query);
   axios
     .get(query)
     .then((response) => {
-      const firstTenParsed = response.data.items.map((book) => {
+      const responseParsed = response.data.items.map((book) => {
         return {
           googleId: book.id,
           title: book.volumeInfo.title,
@@ -22,7 +36,7 @@ router.get('/', (req, res) => {
       res.status(200).json({
         totalItems: response.data.totalItems,
         returnedItemsLength: response.data.items.length,
-        firstTen: firstTenParsed,
+        results: responseParsed,
       });
     })
     .catch((err) => {

--- a/api/routes/shelfBookConnections.js
+++ b/api/routes/shelfBookConnections.js
@@ -1,0 +1,110 @@
+const express = require('express');
+// const authRequired = require('../middleware/authRequired');
+const shelfBookConnections = require('../models/shelfBookConnectionModel');
+const router = express.Router();
+
+router.get('/', function (req, res) {
+  shelfBookConnections
+    .findAll()
+    .then((connections) => {
+      res.status(200).json(connections);
+    })
+    .catch((err) => {
+      res.status(500).json({
+        message: 'Failure to GET shelf-book connections',
+        error: err.message,
+      });
+    });
+});
+
+router.get('/:id', function (req, res) {
+  const id = String(req.params.id);
+  shelfBookConnections
+    .findById(id)
+    .then((connection) => {
+      if (connection) {
+        res.status(200).json(connection);
+      } else {
+        res
+          .status(404)
+          .json({ error: `Shelf-book connection with id ${id} not found.` });
+      }
+    })
+    .catch((err) => {
+      res.status(500).json({
+        message: `Failure to GET shelf-book connection with id ${id}.`,
+        error: err.message,
+      });
+    });
+});
+
+router.post('/:shelfId/:profileBookConnectionId', (req, res) => {
+  const ShelfId = String(req.params.shelfId);
+  const ConnectionId = String(req.params.profileBookConnectionId);
+  shelfBookConnections
+    .findBy({ ShelfId, ConnectionId })
+    .first()
+    .then((connectionResult) => {
+      if (connectionResult == undefined) {
+        // shelf-book connection not found, so let's create it:
+        shelfBookConnections
+          .create({ ShelfId, ConnectionId })
+          .then((newConnection) => {
+            res.status(200).json({
+              message: 'shelf-book connection created',
+              connection: newConnection,
+            });
+          })
+          .catch((err) => {
+            console.error(err);
+            res.status(500).json({
+              message: 'Failure to create new shelf-book connection',
+              error: err.message,
+            });
+          });
+      } else {
+        res.status(400).json({
+          message: `shelf-book connection with id ${connectionResult.id} already exists`,
+        });
+      }
+    })
+    .catch((err) => {
+      console.error(err);
+      res.status(500).json({ message: err.message });
+    });
+});
+
+router.delete('/:id', (req, res) => {
+  const id = req.params.id;
+  shelfBookConnections
+    .findById(id)
+    .then((connection) => {
+      if (connection) {
+        shelfBookConnections
+          .remove(id)
+          .then((deleted) => {
+            res.status(200).json({
+              message: `Shelf-book connection with id ${id} was deleted.`,
+              count_of_deleted_connections: deleted,
+            });
+          })
+          .catch((err) => {
+            res.status(500).json({
+              message: `Could not delete shelf-book connection with id: ${id}`,
+              error: err.message,
+            });
+          });
+      } else {
+        res.status(404).json({
+          error: `Shelf-book connection with id ${id} not found.`,
+        });
+      }
+    })
+    .catch((err) => {
+      res.status(500).json({
+        message: `Shelf-book connection with id ${id} not found.`,
+        error: err.message,
+      });
+    });
+});
+module.exports = router;

--- a/api/routes/shelfBookConnections.js
+++ b/api/routes/shelfBookConnections.js
@@ -1,6 +1,7 @@
 const express = require('express');
 // const authRequired = require('../middleware/authRequired');
 const shelfBookConnections = require('../models/shelfBookConnectionModel');
+const Shelves = require('../models/shelfModel');
 const router = express.Router();
 
 router.get('/', function (req, res) {
@@ -36,6 +37,37 @@ router.get('/:id', function (req, res) {
         error: err.message,
       });
     });
+});
+
+// To GET the shelf-book connections for a specified shelf
+
+router.get('/shelf/:shelfId', function (req, res) {
+  const ShelfId = String(req.params.shelfId);
+  Shelves.findById(ShelfId).then((shelfResponse) => {
+    if (shelfResponse) {
+      shelfBookConnections
+        .findBy({ ShelfId })
+        .then((connections) => {
+          if (connections) {
+            res.status(200).json(connections);
+          } else {
+            res.status(404).json({
+              error: `Shelf-book connections where ShelfId is ${ShelfId} are not found.`,
+            });
+          }
+        })
+        .catch((err) => {
+          res.status(500).json({
+            message: `Failure to GET shelf-book connections where ShelfId is ${ShelfId}.`,
+            error: err.message,
+          });
+        });
+    } else {
+      res.status(404).json({
+        error: `Shelf with ShelfId ${ShelfId} was not found.`,
+      });
+    }
+  });
 });
 
 router.post('/:shelfId/:profileBookConnectionId', (req, res) => {

--- a/api/routes/shelves.js
+++ b/api/routes/shelves.js
@@ -14,4 +14,51 @@ router.get('/', function (req, res) {
     });
 });
 
+router.get('/:id', function (req, res) {
+  const id = String(req.params.id);
+  Shelves.findById(id)
+    .then((shelf) => {
+      if (shelf) {
+        res.status(200).json(shelf);
+      } else {
+        res.status(404).json({ error: 'ShelfNotFound' });
+      }
+    })
+    .catch((err) => {
+      res.status(500).json({ error: err.message });
+    });
+});
+
+router.post('/', (req, res) => {
+  const shelf = req.body;
+  if (shelf) {
+    const id = shelf.id || 0;
+    Shelves.findBy({ id })
+      .first()
+      .then((sr) => {
+        if (sr == undefined) {
+          //shelf not found so let's insert it
+          Shelves.create(shelf)
+            .then((created_shelf) => {
+              res
+                .status(200)
+                .json({ message: 'shelf created', shelf: created_shelf });
+            })
+            .catch((err) => {
+              console.error(err);
+              res.status(500).json({ message: err.message });
+            });
+        } else {
+          res.status(400).json({ message: 'shelf already exists' });
+        }
+      })
+      .catch((err) => {
+        console.error(err);
+        res.status(500).json({ message: err.message });
+      });
+  } else {
+    res.status(400).json({ message: 'shelf info is missing in request body' });
+  }
+});
+
 module.exports = router;

--- a/api/routes/shelves.js
+++ b/api/routes/shelves.js
@@ -1,6 +1,7 @@
 const express = require('express');
 // const authRequired = require('../middleware/authRequired');
 const Shelves = require('../models/shelfModel');
+const Profiles = require('../models/profileModel');
 const router = express.Router();
 
 router.get('/', function (req, res) {
@@ -22,6 +23,40 @@ router.get('/:id', function (req, res) {
         res.status(200).json(shelf);
       } else {
         res.status(404).json({ error: 'ShelfNotFound' });
+      }
+    })
+    .catch((err) => {
+      res.status(500).json({ error: err.message });
+    });
+});
+
+// GET all shelves of specified user only
+
+router.get('/profile/:id', function (req, res) {
+  const profileId = String(req.params.id);
+  // First, check that profileId is for a valid user
+  Profiles.findById(profileId)
+    .then((pr) => {
+      if (pr) {
+        // Then, find all shelves belonging to this user
+        Shelves.findBy({ profileId })
+          .then((shelves) => {
+            if (shelves) {
+              res.status(200).json(shelves);
+            } else {
+              res.status(404).json({
+                error: `Shelves for user with profile id ${profileId} not found.`,
+              });
+            }
+          })
+          .catch((err) => {
+            res.status(500).json({
+              message: `Failure to GET shelves for user with profile id ${profileId}.`,
+              error: err.message,
+            });
+          });
+      } else {
+        res.status(404).json({ error: 'ProfileNotFound' });
       }
     })
     .catch((err) => {

--- a/api/routes/shelves.js
+++ b/api/routes/shelves.js
@@ -1,0 +1,17 @@
+const express = require('express');
+// const authRequired = require('../middleware/authRequired');
+const Shelves = require('../models/shelfModel');
+const router = express.Router();
+
+router.get('/', function (req, res) {
+  Shelves.findAll()
+    .then((shelves) => {
+      res.status(200).json(shelves);
+    })
+    .catch((err) => {
+      console.log(err);
+      res.status(500).json({ message: err.message });
+    });
+});
+
+module.exports = router;

--- a/api/routes/shelves.js
+++ b/api/routes/shelves.js
@@ -98,4 +98,36 @@ router.put('/:id', (req, res) => {
   }
 });
 
+router.delete('/:id', (req, res) => {
+  const id = req.params.id;
+  Shelves.findById(id)
+    .then((shelf) => {
+      if (shelf) {
+        Shelves.remove(id)
+          .then((deleted) => {
+            res.status(200).json({
+              message: `Shelf with id ${id} was deleted.`,
+              count_of_deleted_shelves: deleted,
+            });
+          })
+          .catch((err) => {
+            res.status(500).json({
+              message: `Could not delete shelf with id: ${id}`,
+              error: err.message,
+            });
+          });
+      } else {
+        res.status(404).json({
+          error: `Shelf with id ${id} not found.`,
+        });
+      }
+    })
+    .catch((err) => {
+      res.status(500).json({
+        message: `Shelf with id ${id} not found.`,
+        error: err.message,
+      });
+    });
+});
+
 module.exports = router;

--- a/api/routes/shelves.js
+++ b/api/routes/shelves.js
@@ -61,4 +61,41 @@ router.post('/', (req, res) => {
   }
 });
 
+router.put('/:id', (req, res) => {
+  const id = String(req.params.id);
+  const shelfInfo = req.body;
+  if (shelfInfo) {
+    Shelves.findById(id)
+      .then((shelfResponse) => {
+        if (shelfResponse == undefined) {
+          res.status(400).json({
+            message: `Shelf with id ${id} not found.`,
+          });
+        } else {
+          Shelves.update(id, shelfInfo)
+            .then((updatedShelf) => {
+              res.status(200).json({
+                message: `Shelf with id ${id} is updated.`,
+                shelf: updatedShelf,
+              });
+            })
+            .catch((err) => {
+              res.status(500).json({
+                message: `Failure to update shelf with id ${id}`,
+                error: err.message,
+              });
+            });
+        }
+      })
+      .catch((err) => {
+        console.error(err);
+        res.status(500).json({ message: err.message });
+      });
+  } else {
+    res.status(400).json({
+      message: 'Request body is missing the shelf info needed for an update.',
+    });
+  }
+});
+
 module.exports = router;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1262,6 +1262,14 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
       "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      }
+    },
     "babel-jest": {
       "version": "25.5.1",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-25.5.1.tgz",
@@ -3205,6 +3213,24 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@okta/jwt-verifier": "^1.0.0",
+    "axios": "^0.19.2",
     "cookie-parser": "~1.4.4",
     "cors": "^2.8.5",
     "debug": "~2.6.9",


### PR DESCRIPTION
Includes routes for books, book search, profile-book connections, shelves, and shelf-book connections.
Adds some tests for each route. (More tests should be added later.)
I also tested the routes with Postman (https://documenter.getpostman.com/view/9937137/T1DpBxR7?version=latest).